### PR TITLE
Debug scene change on spacebar press

### DIFF
--- a/GameManager.cs
+++ b/GameManager.cs
@@ -52,6 +52,8 @@ public class GameManager : MonoBehaviour
     private NoteChart chart;
     private bool[] noteSpawned;   // 노트가 생성됐는지 여부 저장
     public static GameManager Instance;
+    public static string SelectedSongTitle;
+    public static string SelectedSongArtist;
 
     public Transform judgementLine;      // 에디터에서 드래그
     public float scrollSpeed = 10f;       // 초당 유닛 이동
@@ -82,6 +84,9 @@ public class GameManager : MonoBehaviour
     }
     void Start()
     {
+        songTitle = SelectedSongTitle;
+        songArtist = SelectedSongArtist;
+
         // JSON 파일 로드
         TextAsset json = Resources.Load<TextAsset>(songTitle.ToString() + " - " + songArtist.ToString()+"/" + "EZ");
         chart = JsonUtility.FromJson<NoteChart>(json.text);

--- a/SongManager.cs
+++ b/SongManager.cs
@@ -172,8 +172,8 @@ public class SongManager : MonoBehaviour
 
     void SelectSong(string title, string artist)
     {
-        GameManager.Instance.songTitle = title;
-        GameManager.Instance.songArtist = artist;
+        GameManager.SelectedSongTitle = title;
+        GameManager.SelectedSongArtist = artist;
         SceneManager.LoadScene("MainScene");
     }
 }


### PR DESCRIPTION
Fixes scene change failure by using static fields to pass song selection data, avoiding a NullReferenceException when `GameManager.Instance` is not present in the selection scene.

The previous implementation attempted to set `GameManager.Instance.songTitle` and `GameManager.Instance.songArtist` from `SongManager` in a scene where no `GameManager` instance existed. This caused a `NullReferenceException` and prevented the `SceneManager.LoadScene` call from executing. Using static fields allows the data to be passed between scenes without requiring an active `GameManager` instance in the initial scene.

---
<a href="https://cursor.com/background-agent?bcId=bc-ccab968a-5d86-461f-9c3e-aabeee8b9699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ccab968a-5d86-461f-9c3e-aabeee8b9699">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

